### PR TITLE
Fixes an issue with Travis build 

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,8 @@ LARAVEL_ROOT="$OPENBENCHMARK_DIR/web/public"
 GROUP="$( id -gn )"
 INDEX_JS_PATH="$OPENBENCHMARK_DIR/experiment-control/nodejs_websocket/index.js"
 
+sudo apt-mark hold mysql-server-5.7
+
 sudo apt-get -y update
 sudo apt-get -y upgrade
 sudo apt-get install -y software-properties-common

--- a/experiment-control/otbox_startup.py
+++ b/experiment-control/otbox_startup.py
@@ -1,3 +1,4 @@
+import warnings
 import paramiko
 import json
 import subprocess
@@ -5,6 +6,7 @@ import time
 import threading
 import os
 
+from cryptography.utils import CryptographyDeprecationWarning
 from socket_io_handler import SocketIoHandler
 from reservation import Reservation
 
@@ -24,6 +26,11 @@ class OTBoxStartup:
 
 
 	def __init__(self, user, domain, testbed):
+		warnings.simplefilter(
+			action='ignore',
+			category=CryptographyDeprecationWarning
+		)
+
 		self.user            = user
 		self.domain          = domain
 		self.testbed         = testbed
@@ -33,6 +40,11 @@ class OTBoxStartup:
 		self.client          = paramiko.SSHClient()
 		self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 		self.client.load_system_host_keys()
+
+		paramiko_log_path = os.path.join(os.path.dirname(__file__), "logs")
+		if not os.path.exists(paramiko_log_path):
+			os.mkdir(paramiko_log_path)
+		paramiko.util.log_to_file(os.path.join(paramiko_log_path, 'otbox_paramiko.log'))
 
 		self.ssh_connect()
 

--- a/experiment-control/reservation.py
+++ b/experiment-control/reservation.py
@@ -1,9 +1,12 @@
 from socket_io_handler import SocketIoHandler
 from exp_terminate import ExpTerminate
+from cryptography.utils import CryptographyDeprecationWarning
 
+import warnings
 import paramiko
 import json
 import time
+import os
 
 class Reservation:
 
@@ -13,6 +16,11 @@ class Reservation:
 	CHECK_PAUSE    = 30
 
 	def __init__(self, user, domain):
+		warnings.simplefilter(
+			action='ignore',
+			category=CryptographyDeprecationWarning
+		)
+
 		self.user   = user
 		self.domain = domain
 
@@ -21,6 +29,11 @@ class Reservation:
 		self.client = paramiko.SSHClient()
 		self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 		self.client.load_system_host_keys()
+		
+		paramiko_log_path = os.path.join(os.path.dirname(__file__), "logs")
+		if not os.path.exists(paramiko_log_path):
+			os.mkdir(paramiko_log_path)
+		paramiko.util.log_to_file(os.path.join(paramiko_log_path, 'reservation_paramiko.log'))
 
 		self.ssh_connect()
 

--- a/experiment-control/test/testbed.py
+++ b/experiment-control/test/testbed.py
@@ -5,6 +5,7 @@ import subprocess
 import os
 import time
 import json
+import warnings
 
 
 class Testbed():


### PR DESCRIPTION
This PR mitigates problems that were occuring during Travis builds when upgrading `mysql-server-5.7` package and also gets rid of false negatives caused by warnings generated by third party libraries (Paramiko). The PR "holds" `mysql-server-5.7` package from upgrading and PR filters out all warnings of `CryptographyDeprecationWarning` type generated by Paramiko package from stderr. Additionally it writes all Paramiko logs to a separate file.