### PR TITLE
Fix bootstrap refactoring bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ before_script:
   - bash bootstrap_jfed.sh
 
 script:
-  - sudo service index stop
-  - node ./experiment-provisioner/nodejs_websocket/index.js > index.log 2>&1 &
   - pytest ./experiment-provisioner/test/test.py -s
   - cd docs; make html
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ before_script:
   - bash bootstrap.sh
   - dos2unix bootstrap_webdev.sh
   - bash bootstrap_webdev.sh
-  - dos2unix bootstrap_jfed.sh
-  - bash bootstrap_jfed.sh
 
 script:
   - pytest ./experiment-provisioner/test/test.py -s

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,9 +68,6 @@ Vagrant.configure("2") do |config|
     dos2unix ./openbenchmark/bootstrap_webdev.sh
     dos2unix ./openbenchmark/bootstrap_jfed.sh
     dos2unix ./openbenchmark/experiment-control/helpers/wilab/jfed_cli/*.sh
-    bash ./openbenchmark/bootstrap.sh
-    bash ./openbenchmark/bootstrap_webdev.sh
-    bash ./openbenchmark/bootstrap_jfed.sh
   SHELL
 
 end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,8 +31,13 @@ git clone https://github.com/openwsn-berkeley/openvisualizer.git
 git clone https://github.com/openwsn-berkeley/coap.git
 cd $OPENWSN_DIR/openwsn-fw/
 sudo apt-get install -y python-dev
+
+# Installing Python pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+sudo python get-pip.py
+rm get-pip.py
+
 sudo apt-get install -y scons
-sudo apt-get install -y python-pip
 cd $OPENWSN_DIR/openvisualizer/
 sudo apt-get install -y python-tk
 sudo pip install -r requirements.txt --ignore-installed
@@ -59,7 +64,6 @@ git remote add -t $TAG_OV -f repository $REPO_OV
 git checkout $TAG_OV
 
 # Install OpenBenchmark requirements; OpenBenchmark scripts do not run with sudo
-pip install --upgrade pip
 pip install -r $OPENBENCHMARK_DIR/requirements.txt --user
 
 ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,7 @@ set -o xtrace
 export LC_ALL=en_US.UTF-8
 
 OPENBENCHMARK_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+OPENWSN_DIR=$OPENBENCHMARK_DIR/../openwsn
 
 # FIXME private branch, change to the official repo once code is merged
 TAG_COAP=develop_COAP-44
@@ -22,25 +23,25 @@ sudo apt -y install git
 
 ### Below is a verbatim copy of the OpenWSN install.sh script
 # until a typo in openvisualizer installation gets fixed
-mkdir openwsn
+mkdir $OPENWSN_DIR
 sudo apt-get install -y git
-cd ./openwsn/
+cd $OPENWSN_DIR
 git clone https://github.com/openwsn-berkeley/openwsn-fw.git
 git clone https://github.com/openwsn-berkeley/openvisualizer.git
 git clone https://github.com/openwsn-berkeley/coap.git
-cd ./openwsn-fw/
+cd $OPENWSN_DIR/openwsn-fw/
 sudo apt-get install -y python-dev
 sudo apt-get install -y scons
-cd ../openvisualizer/
 sudo apt-get install -y python-pip
+cd $OPENWSN_DIR/openvisualizer/
 sudo apt-get install -y python-tk
 sudo pip install -r requirements.txt --ignore-installed
-cd ../coap/
+cd $OPENWSN_DIR/coap/
 sudo pip install -r requirements.txt
 sudo apt-get install -y gcc-arm-none-eabi
 sudo apt-get install -y gcc-msp430
 
-cd ../..
+cd $OPENBENCHMARK_DIR
 ### End of OpenWSN install.sh script copy
 
 wget https://openwsn.atlassian.net/wiki/download/attachments/29196302/install.sh 
@@ -48,12 +49,12 @@ wget https://openwsn.atlassian.net/wiki/download/attachments/29196302/install.sh
 rm install.sh
 
 # Update OpenWSN-CoAP with the correct commit name
-cd ./openwsn/coap
+cd $OPENWSN_DIR/coap
 git remote add -t $TAG_COAP -f repository $REPO_COAP
 git checkout $TAG_COAP
 
 # Update OpenVisualizer with the correct commit name
-cd ../openvisualizer
+cd $OPENWSN_DIR/openvisualizer
 git remote add -t $TAG_OV -f repository $REPO_OV
 git checkout $TAG_OV
 

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -10,6 +10,12 @@ OPENBENCHMARK_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 JFED_DIR=$OPENBENCHMARK_DIR/experiment-provisioner/helpers/wilab/jfed_cli
 JVM_DIR="/usr/lib/jvm"
 
+if [ ! -d $JVM_DIR ]; then
+	sudo mkdir $JVM_DIR
+fi
+
+sudo apt-get install unzip
+
 # Java 11 and JavaFX 11 download
 cd $JFED_DIR
 	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -35,6 +35,9 @@ sudo apt-get install xvfb -y
 sudo apt-get install x11-xserver-utils -y
 
 # jFED installation
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+
 sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys E7F4995E
 echo "deb http://jfed.ilabt.imec.be/deb-repo stable main" | sudo tee /etc/apt/sources.list.d/jfed.list
 sudo apt-get update

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -8,15 +8,16 @@ set -o xtrace
 
 OPENBENCHMARK_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 JFED_DIR=$OPENBENCHMARK_DIR/experiment-provisioner/helpers/wilab/jfed_cli
+JVM_DIR="/usr/lib/jvm"
 
 # Java 11 and JavaFX 11 download
 cd $JFED_DIR
-if [ ! -f "/usr/lib/jvm/jdk-11.0.2" ]; then
 	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
 	sudo tar xfz openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
 	rm openjdk-11.0.2_linux-x64_bin.tar.gz
+if [ ! -f "$JVM_DIR/jdk-12.0.1" ]; then
 fi
-if [ ! -f "/usr/lib/jvm/javafx-sdk-11.0.2" ]; then
+if [ ! -f "$JVM_DIR/javafx-sdk-11.0.2" ]; then
 	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
 	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
 	rm openjfx-11.0.2_linux-x64_bin-sdk.zip

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -18,10 +18,11 @@ sudo apt-get install unzip
 
 # Java 11 and JavaFX 11 download
 cd $JFED_DIR
-	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
-	sudo tar xfz openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
-	rm openjdk-11.0.2_linux-x64_bin.tar.gz
 if [ ! -f "$JVM_DIR/jdk-12.0.1" ]; then
+	wget https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
+	sudo tar xfz zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz --directory /usr/lib/jvm
+	rm zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
+	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/jdk12.0.1
 fi
 if [ ! -f "$JVM_DIR/javafx-sdk-11.0.2" ]; then
 	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -11,12 +11,12 @@ JFED_DIR=$OPENBENCHMARK_DIR/experiment-provisioner/helpers/wilab/jfed_cli
 
 # Java 11 and JavaFX 11 download
 cd $JFED_DIR
-if [ ! -f "/usr/lib/jvm/jdk-11.0.2"]; then
+if [ ! -f "/usr/lib/jvm/jdk-11.0.2" ]; then
 	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
 	sudo tar xfz openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
 	rm openjdk-11.0.2_linux-x64_bin.tar.gz
 fi
-if [ ! -f "/usr/lib/jvm/javafx-sdk-11.0.2"]; then
+if [ ! -f "/usr/lib/jvm/javafx-sdk-11.0.2" ]; then
 	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
 	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
 	rm openjfx-11.0.2_linux-x64_bin-sdk.zip

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -9,6 +9,23 @@ set -o xtrace
 OPENBENCHMARK_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 JFED_DIR=$OPENBENCHMARK_DIR/experiment-provisioner/helpers/wilab/jfed_cli
 
+# Java 11 and JavaFX 11 download
+cd $JFED_DIR
+if [ ! -f "/usr/lib/jvm/jdk-11.0.2"]; then
+	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+	sudo tar xfz openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
+	rm openjdk-11.0.2_linux-x64_bin.tar.gz
+fi
+if [ ! -f "/usr/lib/jvm/javafx-sdk-11.0.2"]; then
+	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
+	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
+	rm openjfx-11.0.2_linux-x64_bin-sdk.zip
+fi
+
+# Install xvfb and xrandr
+sudo apt-get install xvfb -y
+sudo apt-get install x11-xserver-utils -y
+
 # jFED installation
 sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys E7F4995E
 echo "deb http://jfed.ilabt.imec.be/deb-repo stable main" | sudo tee /etc/apt/sources.list.d/jfed.list
@@ -27,23 +44,6 @@ rm -rf jfed_cli
 if [ ! -d "opentestbed" ]; then
 	git clone -b espec --single-branch https://github.com/twalcari/opentestbed.git
 fi
-
-# Java 11 and JavaFX 11 download
-cd $JFED_DIR
-if [ ! -f "/usr/lib/jvm/jdk-11.0.2"]; then
-	wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
-	sudo tar xfz openjdk-11.0.2_linux-x64_bin.tar.gz --directory /usr/lib/jvm
-	rm openjdk-11.0.2_linux-x64_bin.tar.gz
-fi
-if [ ! -f "/usr/lib/jvm/javafx-sdk-11.0.2"]; then
-	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
-	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
-	rm openjfx-11.0.2_linux-x64_bin-sdk.zip
-fi
-
-# Install xvfb and xrandr
-sudo apt-get install xvfb -y
-sudo apt-get install x11-xserver-utils -y
 
 # jFed proxy configuration
 mkdir -p ~/.jFed


### PR DESCRIPTION
Changes introduced with this PR:

- Provisioner module adjusted to the changes made with bootstrap refactoring (as described in issue #43)
- Removes websocket service startup from Travis configuration file (in accordance to issue #44)
- Removes bootstrap scripts startup directly from Vagrant file
- Further adjusts bootstrap scripts (according to issue #43)
- Temporarily removes `bootstrap_jfed.sh` startup from Travis configuration file due to an existing problem with jFed installation