### PR TITLE
Enhancement/fw upload

### DIFF
--- a/web/app/Http/Controllers/ExperimentController.php
+++ b/web/app/Http/Controllers/ExperimentController.php
@@ -8,10 +8,13 @@ use ConfigParser;
 use App\Classes\ErrorResponse;
 use App\Experiment;
 use App\Classes\SuccessResponse;
+use Exception;
 
 
 class ExperimentController extends Controller
 {
+
+    const FILE_DESTINATION = "/home/vagrant/openbenchmark/experiment-provisioner/firmware";
 
     function __construct() {
         $this->config_parser   = new ConfigParser();
@@ -32,10 +35,25 @@ class ExperimentController extends Controller
         $this->cmd_handler->start_ov($this->user_id, $scenario, $testbed, ($simulator == "true"), false);
     }
 
-    function upload() {
-        return response()->json([
-            'status' => 'success'
-        ]);
+    function upload(Request $request) {
+        try {
+            $file = $request->file("file");
+            $new_filename = $this->create_random(10);
+
+            if ($file != null) {
+                $file->move(self::FILE_DESTINATION, $new_filename);
+
+                return SuccessResponse::response(200, [
+                    "action" => "firmware-upload",
+                    "name"   => $new_filename,
+                ]);
+            } else {
+                throw new Exception("Error uploading the file");
+            }
+
+        } catch (Exception $e) {
+            return ErrorResponse::response(500, $e->getMessage());
+        }
     }
 
 

--- a/web/resources/assets/js/app.js
+++ b/web/resources/assets/js/app.js
@@ -19,9 +19,6 @@ Vue.component('arrow', require('./components/reusables/Arrow.vue').default);
 Vue.component('multiselect', require('vue-multiselect').default);
 Vue.component('progress-bar', require('./components/reusables/ProgressBar.vue').default);
 
-//Vue.use(VueSocketio, io('http://89.188.32.132:3000'));
-//Vue.use(VueSocketio, io('http://192.168.10.192:3000'));
-Vue.use(VueSocketio, io('http://127.0.0.1:3000'));
 Vue.use(Vuebar);
 
 Vue.directive('observe-visibility', ObserveVisibility);

--- a/web/resources/assets/js/components/landing/Scenarios.vue
+++ b/web/resources/assets/js/components/landing/Scenarios.vue
@@ -140,7 +140,9 @@
                 ],
 
                 currentStep: -2,   //If -2, process has not started yet; -1: process started, waiting for notifications
-                taskFailed: false
+                taskFailed: false,
+
+                firmware: ""
             }
         },
 
@@ -248,19 +250,26 @@
             },
 
             processStart() {
-                this.currentStep = -1
                 let scenario = this.scenarios[this.scenarioSelected].identifier
                 let testbed  = this.testbeds[this.testbedSelected].identifier
                 
-                //Currently, simulator is hardcoded to 'true', and 'firmware' is omitted
-                axios.get('/api/start-exp/' + scenario + '/' + testbed + '/false') 
+                let route = '/api/start-exp/' + scenario + '/' + testbed + '/false'
+
+                if (this.firmware && this.firmware !== "") {
+                    route += '/' + this.firmware
+                }
+
+                thisComponent.currentStep = -1
+
+                axios.get(route) 
                     .then(function (response) {
                         // handle success
-                        console.log(response);
+                        console.log(response)
                     })
                     .catch(function (error) {
                         // handle error
-                        console.log(error);
+                        console.log(error)
+                        thisComponent.currentStep = -2
                     })
 
                 axios.post('/api/store', {
@@ -450,6 +459,14 @@
                 thisComponent.markNode(payload, 'failed', true);
             });
 
+            this.$eventHub.$on("FIRMWARE_UPLOADED", payload => {
+                if (payload.http_code == 200) {
+                    thisComponent.firmware = payload.message.name
+                    console.log("Firmware successfully uploaded: " + thisComponent.firmware);
+                } else {
+                    console.log("Error uploading firmware. Will revert to default OpenWSN");
+                }
+            });
         }
     }
 </script>

--- a/web/resources/assets/js/components/reusables/FileUploadSimple.vue
+++ b/web/resources/assets/js/components/reusables/FileUploadSimple.vue
@@ -78,19 +78,44 @@
             },
             inputFile(newFile, oldFile) {
                 if (newFile && !oldFile) {
-                    // add
-                    console.log('add', newFile)
+                    this.processResponse(newFile)
+                    console.log('add')
                 }
                 if (newFile && oldFile) {
-                    // update
-                    console.log('update', newFile)
+                    this.processResponse(newFile)
+                    console.log('update')
                 }
                 if (!newFile && oldFile) {
                     // remove
-                    console.log('remove', oldFile)
+                    console.log('remove')
+                }
+            },
+
+            processResponse(newFile) {
+                if (newFile.xhr && newFile.xhr.status > 0) {
+                    this.$eventHub.$emit('FIRMWARE_UPLOADED', newFile.response)
+                } else {
+                    console.log('Firmware upload failed')
                 }
             }
+        },
+
+        filters: {
+            formatSize(size) {
+                if (size > 1024 * 1024 * 1024 * 1024) {
+                    return (size / 1024 / 1024 / 1024 / 1024).toFixed(2) + ' TB'
+                } else if (size > 1024 * 1024 * 1024) {
+                    return (size / 1024 / 1024 / 1024).toFixed(2) + ' GB'
+                } else if (size > 1024 * 1024) {
+                    return (size / 1024 / 1024).toFixed(2) + ' MB'
+                } else if (size > 1024) {
+                    return (size / 1024).toFixed(2) + ' KB'
+                }
+                
+                return size.toString() + ' B'
+            }
         }
+
     }
 </script>
 

--- a/web/resources/assets/js/pages/Home.vue
+++ b/web/resources/assets/js/pages/Home.vue
@@ -90,78 +90,10 @@
             this.$eventHub.$on("SIDEBAR_SCROLL", payload => {
                 thisComponent.sidebarScroll = true;
             });
-            this.$eventHub.$on("LOG_MODIFICATION", payload => {
-                this.dataFlowStarted = true;
-            });
-            this.$eventHub.$on("EXP_TERMINATE", payload => {
-                this.dataFlowStarted = false;
-            });
         },
 
         created() {
             thisComponent = this;
-
-            this.$socket.on('connect', function() {
-                console.log('Socket connected!');
-                thisComponent.registerChannel();
-
-                socketConnected = true;
-            });
-
-            this.$socket.on('NODE_RESERVATION', function(data) {
-                thisComponent.forwardMessage('NODE_RESERVATION', data);
-                console.log('NODE_RESERVATION: ' + data);
-            });
-            this.$socket.on('RESERVATION_SUCCESS', function(data) {
-                thisComponent.forwardMessage('RESERVATION_SUCCESS', data);
-                console.log('RESERVATION_SUCCESS: ' + data);
-            });
-            this.$socket.on('RESERVATION_STATUS_RETRY', function(data) {
-                thisComponent.forwardMessage('RESERVATION_STATUS_RETRY', data);
-                console.log('RESERVATION_STATUS_RETRY: ' + data);
-            });
-            this.$socket.on('RESERVATION_FAIL', function(data) {
-                thisComponent.forwardMessage('RESERVATION_FAIL', data);
-                console.log('RESERVATION_FAIL: ' + data);
-            });
-
-            this.$socket.on('NODE_BOOTED', function(data) {
-                thisComponent.forwardMessage('NODE_BOOTED', data);
-                console.log('NODE_BOOTED: ' + data);
-            });
-            this.$socket.on('BOOT_RETRY', function(data) {
-                thisComponent.forwardMessage('BOOT_RETRY', data);
-                console.log('BOOT_RETRY: ' + data);
-            });
-            this.$socket.on('BOOT_FAIL', function(data) {
-                thisComponent.forwardMessage('BOOT_FAIL', data);
-                console.log('BOOT_FAIL: ' + data);
-            });
-
-            this.$socket.on('NODE_ACTIVE', function(data) {
-                thisComponent.forwardMessage('NODE_ACTIVE', data);
-                console.log('NODE_ACTIVE: ' + data);
-            });
-            this.$socket.on('NODE_ACTIVE_FAIL', function(data) {
-                thisComponent.forwardMessage('NODE_ACTIVE_FAIL', data);
-                console.log('NODE_ACTIVE_FAIL: ' + data);
-            });
-
-            this.$socket.on('LOG_MODIFICATION', function(data) {
-                thisComponent.forwardMessage('LOG_MODIFICATION', data);
-                console.log('LOG_MODIFICATION: ' + data);
-            });
-
-            this.$socket.on('EXP_TERMINATE', function(data) {
-                thisComponent.forwardMessage('EXP_TERMINATE', data);
-                console.log('EXP_TERMINATE: ' + data);
-            });
-
-            setTimeout(function() {
-                if (!socketConnected) {
-                    thisComponent.registerChannel();
-                }
-            }, 200);
         }
     }
 </script>


### PR DESCRIPTION
This PR writes the logic for accepting a firmware file from the GUI, saving it in `firmware` directory of the `experiment-provisioner` under a randomly generated 10-character name, and starting the provisioner with the provided firmware name as the value of `--firmware` parameter. Additionally, it removes some of the unused logic for operating with socket.io websocket service