### PR TITLE
Wilab provisioning update

### DIFF
--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -34,15 +34,6 @@ fi
 sudo apt-get install xvfb -y
 sudo apt-get install x11-xserver-utils -y
 
-# jFED installation
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
-sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
-
-sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys E7F4995E
-echo "deb http://jfed.ilabt.imec.be/deb-repo stable main" | sudo tee /etc/apt/sources.list.d/jfed.list
-sudo apt-get update
-sudo apt-get -y install jfed 
-
 # jFED CLI tools download
 cd $JFED_DIR
 wget https://jfed.ilabt.imec.be/releases/develop/190206-192/jar/jfed_cli.tar.gz

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -20,14 +20,15 @@ sudo apt-get install unzip
 cd $JFED_DIR
 if [ ! -f "$JVM_DIR/jdk-12.0.1" ]; then
 	wget https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
-	sudo tar xfz zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz --directory /usr/lib/jvm
+	sudo tar xfz zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz --directory $JVM_DIR
 	rm zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
-	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/jdk12.0.1
+	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/jdk-12.0.1
 fi
 if [ ! -f "$JVM_DIR/javafx-sdk-11.0.2" ]; then
 	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
 	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
 	rm openjfx-11.0.2_linux-x64_bin-sdk.zip
+	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/javafx-sdk-11.0.2
 fi
 
 # Install xvfb and xrandr

--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -24,11 +24,10 @@ if [ ! -f "$JVM_DIR/jdk-12.0.1" ]; then
 	rm zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
 	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/jdk-12.0.1
 fi
-if [ ! -f "$JVM_DIR/javafx-sdk-11.0.2" ]; then
-	wget -O openjfx-11.0.2_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-11-0-2-sdk-linux/
-	sudo unzip openjfx-11.0.2_linux-x64_bin-sdk.zip -d /usr/lib/jvm
-	rm openjfx-11.0.2_linux-x64_bin-sdk.zip
-	sudo mv $JVM_DIR/zulu12.2.3-ca-jdk12.0.1-linux_x64 $JVM_DIR/javafx-sdk-11.0.2
+if [ ! -f "$JVM_DIR/javafx-sdk-12.0.1" ]; then
+	wget -O openjfx-12.0.1_linux-x64_bin-sdk.zip http://gluonhq.com/download/javafx-12-0-1-sdk-linux/
+	sudo unzip openjfx-12.0.1_linux-x64_bin-sdk.zip -d /usr/lib/jvm
+	rm openjfx-12.0.1_linux-x64_bin-sdk.zip
 fi
 
 # Install xvfb and xrandr

--- a/experiment-provisioner/helpers/wilab/jfed_cli/start_experiment.sh
+++ b/experiment-provisioner/helpers/wilab/jfed_cli/start_experiment.sh
@@ -1,3 +1,3 @@
-PATH_TO_FX='/usr/lib/jvm/javafx-sdk-11.0.2/lib'
+PATH_TO_FX='/usr/lib/jvm/javafx-sdk-12.0.1/lib'
 export DISPLAY=":99"
-/usr/lib/jvm/jdk-11.0.2/bin/java --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.swing -jar experimenter-cli2.jar --action start_experiment.yml
+/usr/lib/jvm/jdk-12.0.1/bin/java --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.swing -jar experimenter-cli2.jar --action start_experiment.yml

--- a/experiment-provisioner/helpers/wilab/jfed_cli/start_experiment.yml
+++ b/experiment-provisioner/helpers/wilab/jfed_cli/start_experiment.yml
@@ -29,7 +29,7 @@ shareWith:
   projectMembers: false
   users: []
 user:
-  password: *****
+  password: YOUR_PASSWORD
   passwordMethod: DIRECT
   pem:
   - login.pem

--- a/experiment-provisioner/helpers/wilab/jfed_cli/stop_experiment.sh
+++ b/experiment-provisioner/helpers/wilab/jfed_cli/stop_experiment.sh
@@ -1,3 +1,3 @@
-PATH_TO_FX='/usr/lib/jvm/javafx-sdk-11.0.2/lib'                                                                                                              
+PATH_TO_FX='/usr/lib/jvm/javafx-sdk-12.0.1/lib'                                                                                                              
 export DISPLAY=":99"                                                                                                                                         
-/usr/lib/jvm/jdk-11.0.2/bin/java --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.swing -jar experimenter-cli2.jar --action stop_experiment.yml
+/usr/lib/jvm/jdk-12.0.1/bin/java --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.swing -jar experimenter-cli2.jar --action stop_experiment.yml

--- a/experiment-provisioner/helpers/wilab/jfed_cli/stop_experiment.yml
+++ b/experiment-provisioner/helpers/wilab/jfed_cli/stop_experiment.yml
@@ -11,7 +11,7 @@ slice:
   renewExistingSliceIfNeeded: false 
   sliceName: bench00                
 user:                               
-  password: *****                   
+  password: YOUR_PASSWORD                   
   passwordMethod: DIRECT            
   pem:                              
   - login.pem                       

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -146,6 +146,7 @@ class Wilab(Controller):
 		self.BROKER = self.configParser.get(self.CONFIG_SECTION, 'broker')
 
 		self._rspec_update()
+		self._set_broker()
 
 		self.reservation = WilabReservation(user_id, self.JFED_DIR, self.RUN, self.DELETE, self.DISPLAY)
 
@@ -231,7 +232,12 @@ class Wilab(Controller):
 
 		return nucs
 
+	def _set_broker(self):
+		otbox_conf_file = os.path.join(self.JFED_DIR, "opentestbed", "deployment", "sensor", "sensor-supervisord.conf.j2")
+		content = "[program:otbox]\ncommand     = /usr/local/bin/opentestbed -v\nenvironment = OTB_TESTBED='wilab', OTB_BROKER='{0}'\nautostart   = true\nautorestart = true\ndirectory = /tmp".format(self.BROKER)
 
+		with open(otbox_conf_file, 'w') as f:
+			f.write(content)
 
 
 

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -268,6 +268,10 @@ class Wilab(Controller):
 		with open(stop_exp_yml, 'w') as f:
 			yaml.dump(yml_conf, f)
 
+		subprocess.call('dos2unix *.yml', cwd=self.JFED_DIR, shell=True)
+		subprocess.call('dos2unix *.sh', cwd=self.JFED_DIR, shell=True)		
+
+
 	def _get_random_string(self, string_length = 5):
 		letters = string.ascii_uppercase
 		return ''.join(random.choice(letters) for i in range(string_length))

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -147,7 +147,7 @@ class Wilab(Controller):
 
 		self._rspec_update()
 
-		self.reservation = WilabReservation(self.JFED_DIR, self.RUN, self.DELETE, self.DISPLAY)
+		self.reservation = WilabReservation(user_id, self.JFED_DIR, self.RUN, self.DELETE, self.DISPLAY)
 
 	def add_files_from_env(self):
 		if self.CERTIFICATE_B64 != "":

--- a/experiment-provisioner/reservation.py
+++ b/experiment-provisioner/reservation.py
@@ -160,8 +160,8 @@ class IoTLABReservation(Reservation):
 
 class WilabReservation(Reservation):
 
-    def __init__(self, jfed_dir, run, delete, display):
-        self.mqtt_client = MQTTClient.create("wilab")
+    def __init__(self, user_id, jfed_dir, run, delete, display):
+        self.mqtt_client = MQTTClient.create("wilab", user_id)
         
         self.jfed_dir = jfed_dir
         self.actions = {


### PR DESCRIPTION
This PR swaps JavaSDK 11 and JavaFX 11 installation with JavaSDK 12 and JavaFX 12 within Wilab provisioning script. Additionally, it removes the installation of jFed software which was causing provisioning errors and which is not essential for the proper functioning of `experimenter-cli.jar`. Additional changes introduced by this PR:

- OtBox configuration file within `jfed_cli` helper directory is automatically edited by the Experiment Provisioner to contain the valid MQTT broker address chosen by the user
- Experiment duration and slice name parameters are added automatically to action yaml files `start_experiment.yml` and `stop_experiment.yml` by the Experiment Provisioner. Slice name is generated as a unique string starting with "bench" and ending with a random set of characters. Unique slice name is important because choosing an existing slice name may cause an error with the experiment startup
- Automatically performs dos2unix conversion on yaml and sh files to avoid errors caused by Dos newline characters