### PR TITLE
Bug/wilab exp stop

### DIFF
--- a/conf.txt
+++ b/conf.txt
@@ -1,6 +1,7 @@
-[iotlab-config]
+[iotlab]
 user = openbenc
 broker = broker.mqttdashboard.com
 
-[wilab-config]
+[wilab]
 broker = broker.mqttdashboard.com
+password = YOUR_PASSWORD

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1144,7 +1144,7 @@ Experiment Provisioner is a part of the Python core which communicates with the 
 
 Parameter name    | Type    | Choices                                                                    | Required  | Default  
 ----------------- | --------| ---------------------------------------------------------------------------| ----------| --------
---action          | string  | check, reserve, terminate, otbox-flash, ov-start                           | true      | -
+--action          | string  | check, reserve, terminate, flash, ov-start                           | true      | -
 --scenario        | string  | demo-scenario, building-automation, home-automation, industrial-monitoring | false     | demo-scenario
 --testbed         | string  | iotlab, wilab                                                              | false     | iotlab
 --firmware        | string  | - 																		 | false     | 03oos_openwsn_prog

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -142,7 +142,7 @@ class Wilab(Controller):
 		# The nodes will be defined by RSpec file within ESpec directory.
 		# Each scenario should have its own RSpec. RSpecs should be chosen based on scenario config
 		self.JFED_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'helpers', 'wilab', 'jfed_cli'))
-		self.DELETE   = 'delete_experiment.sh' # Script for terminating the experiment
+		self.DELETE   = 'stop_experiment.sh' # Script for terminating the experiment
 		self.RUN      = 'start_experiment.sh'  # Script for starting the experiment
 		self.DISPLAY  = 'start_display.sh'     # Script for starting a fake display
 

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -41,7 +41,7 @@ class Controller(object):
 	        )
 		parser.add_argument('--action', 
 	        dest       = 'action',
-	        choices    = ['check', 'reserve', 'terminate', 'otbox-flash', 'ov-start'],
+	        choices    = ['check', 'reserve', 'terminate', 'flash', 'ov-start'],
 	        required   = True,
 	        action     = 'store'
 		)
@@ -297,13 +297,13 @@ def main():
 	testbed   = args['testbed']
 	scenario  = args['scenario']
 
-	testbed  = TESTBEDS[testbed](user_id, scenario)
+	testbed  = TESTBEDS[testbed](user_id, scenario, action)
 
     # Default firmware is "openwsn" with testbed name suffix
-    if args['firmware'] is None:
-    	firmware = os.path.join(os.path.dirname(__file__), 'firmware', controller.DEFAULT_FIRMWARE + '.' + args['testbed'])
-    else:
-    	firmware = args['firmware']
+	if args['firmware'] is None:
+		firmware = os.path.join(os.path.dirname(__file__), 'firmware', controller.DEFAULT_FIRMWARE + '.' + args['testbed'])
+	else:
+		firmware = args['firmware']
 
 	if action == 'reserve':
             print 'Reserving nodes'
@@ -314,7 +314,7 @@ def main():
 	elif action == 'terminate':
             print 'Terminating experiment'
             testbed.reservation.terminate_experiment()
-	elif action == 'otbox-flash':
+	elif action == 'flash':
             assert firmware is not None
             print 'Flashing firmware: {0}'.format(firmware)
 	    OTBoxFlash(user_id, firmware, testbed.BROKER, args['testbed']).flash()

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -21,7 +21,7 @@ class Controller(object):
 
 	CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "conf.txt")
 	SCENARIO_CONFIG = os.path.join(os.path.dirname(__file__), "..", "scenario-config")
-        DEFAULT_FIRMWARE = '03oos_openwsn_prog'
+	DEFAULT_FIRMWARE = '03oos_openwsn_prog'
 
 	def __init__(self):
 		self.configParser = ConfigParser.RawConfigParser()   
@@ -299,9 +299,11 @@ def main():
 
 	testbed  = TESTBEDS[testbed](user_id, scenario)
 
-        # default firmware is openwsn with testbed name suffix
-        if args['firmware'] is None:
-	    firmware = os.path.join(os.path.dirname(__file__), 'firmware', controller.DEFAULT_FIRMWARE + '.' + args['testbed'])
+    # Default firmware is "openwsn" with testbed name suffix
+    if args['firmware'] is None:
+    	firmware = os.path.join(os.path.dirname(__file__), 'firmware', controller.DEFAULT_FIRMWARE + '.' + args['testbed'])
+    else:
+    	firmware = args['firmware']
 
 	if action == 'reserve':
             print 'Reserving nodes'

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -84,10 +84,10 @@ class Controller(object):
 
 class IoTLAB(Controller):
 
-	def __init__(self, user_id, scenario):
+	def __init__(self, user_id, scenario, action):
 		super(IoTLAB, self).__init__()
 
-		self.CONFIG_SECTION = 'iotlab-config'
+		self.CONFIG_SECTION = 'iotlab'
 		self.scenario = scenario
 
 		self.USERNAME = os.environ["user"] if "user" in os.environ else self.configParser.get(self.CONFIG_SECTION, 'user')
@@ -126,10 +126,10 @@ class IoTLAB(Controller):
 
 class Wilab(Controller):
 
-	def __init__(self, user_id, scenario):
+	def __init__(self, user_id, scenario, action):
 		super(Wilab, self).__init__()
 
-		self.CONFIG_SECTION = 'wilab-config'
+		self.CONFIG_SECTION = 'wilab'
 		self.scenario = scenario
 
 		# Checks if the following files' content has been set as env variables content

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -146,13 +146,14 @@ class Wilab(Controller):
 		self.RUN      = 'start_experiment.sh'  # Script for starting the experiment
 		self.DISPLAY  = 'start_display.sh'     # Script for starting a fake display
 
-		self.BROKER = self.configParser.get(self.CONFIG_SECTION, 'broker')
+		self.BROKER   = self.configParser.get(self.CONFIG_SECTION, 'broker')
+		self.PASSWORD = self.configParser.get(self.CONFIG_SECTION, 'password')
 
 		self.EXP_DURATION = 30
 
 		self._rspec_update()
 		self._set_broker()
-		self._update_yml_files()
+
 		if action == 'reserve':
 			self._update_yml_files()
 
@@ -258,6 +259,7 @@ class Wilab(Controller):
 			yml_conf = yaml.load(f, Loader=yaml.FullLoader)
 			yml_conf['experiment']['slice']['sliceName'] = slice_name
 			yml_conf['experiment']['slice']['expireTimeMin'] = 30
+			yml_conf['user']['password'] = self.PASSWORD
 
 		with open(start_exp_yml, 'w') as f:
 			yaml.dump(yml_conf, f)

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -153,6 +153,8 @@ class Wilab(Controller):
 		self._rspec_update()
 		self._set_broker()
 		self._update_yml_files()
+		if action == 'reserve':
+			self._update_yml_files()
 
 		self.reservation = WilabReservation(user_id, self.JFED_DIR, self.RUN, self.DELETE, self.DISPLAY)
 

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -267,6 +267,7 @@ class Wilab(Controller):
 		with open(stop_exp_yml, 'r') as f:
 			yml_conf = yaml.load(f, Loader=yaml.FullLoader)
 			yml_conf['slice']['sliceName'] = slice_name
+			yml_conf['user']['password'] = self.PASSWORD
 
 		with open(stop_exp_yml, 'w') as f:
 			yaml.dump(yml_conf, f)

--- a/experiment-provisioner/test/mqttTest.py
+++ b/experiment-provisioner/test/mqttTest.py
@@ -15,7 +15,7 @@ class MQTTTest:
 
 		self.pauses = {
 			"reserve":      5,
-			"otbox-flash": 50,
+			"flash": 50,
 			"ov-start":   180 
 		}
 
@@ -27,9 +27,9 @@ class MQTTTest:
 
 
 	def on_connect(self, client, userdata, flags, rc):
-		if self.test_type in ['reserve', 'otbox-flash']:
+		if self.test_type in ['reserve', 'flash']:
 			self.client.subscribe('{0}/deviceType/mote/deviceId/+/notif/frommoteserialbytes'.format(self.testbed))
-			print "[TEST] otbox-flash subscribing..."
+			print "[TEST] flash subscribing..."
 		elif self.test_type == 'ov-start':
 			print "[TEST] ov-start subscribing..."
 			self.client.subscribe('openbenchmark/command/startBenchmark')

--- a/experiment-provisioner/test/test.py
+++ b/experiment-provisioner/test/test.py
@@ -20,7 +20,7 @@ def test_reservation():
 	assert general_test('reserve')
 
 def test_firmware_flash():
-	assert general_test('otbox-flash')
+	assert general_test('flash')
 
 def test_ov_start():
 	assert general_test('ov-start')

--- a/experiment-provisioner/test/testbed.py
+++ b/experiment-provisioner/test/testbed.py
@@ -45,8 +45,8 @@ class Testbed():
 	def output_check(self, action, return_code, stdout = "", stderr = ""):
 		if action == 'reserve':
 			return self.reserve(return_code, stdout, stderr)
-		elif action == 'otbox-flash':
-			return self.otbox_flash(return_code, stdout, stderr)
+		elif action == 'flash':
+			return self.flash(return_code, stdout, stderr)
 		elif action == 'ov-start':
 			return self.ov_start(return_code, stdout, stderr)
 		elif action == 'check':
@@ -61,7 +61,7 @@ class Testbed():
 		pass
 
 	@abstractmethod
-	def otbox_flash(self, return_code, stdout, stderr):
+	def flash(self, return_code, stdout, stderr):
 		pass
 
 	@abstractmethod
@@ -80,8 +80,8 @@ class IoTLAB(Testbed):
 		mqttTest = MQTTTest('iotlab', 'reserve')
 		return return_code == 0 and stderr == '' and mqttTest.check_data()
 
-	def otbox_flash(self, return_code, stdout, stderr):
-		mqttTest = MQTTTest('iotlab', 'otbox-flash')
+	def flash(self, return_code, stdout, stderr):
+		mqttTest = MQTTTest('iotlab', 'flash')
 		return return_code == 0 and stderr == '' and mqttTest.check_data()
 
 	def ov_start(self, return_code, stdout, stderr):

--- a/web/app/Classes/ExperimentController/CommandHandler.php
+++ b/web/app/Classes/ExperimentController/CommandHandler.php
@@ -24,7 +24,7 @@ class CommandHandler {
     }
 
     function flash_firmware($user_id, $firmware, $async=true) {
-        $action = "otbox-flash";
+        $action = "flash";
         $cmd = self::PROVISIONER_MAIN . " --user-id=$user_id --action=$action";
         
         if ($firmware != null)


### PR DESCRIPTION
This PR resolves several bugs regarding experiment provisioning on w-iLab.t and introduces minor changes:
- Yaml action files are edited only upon the experiment startup, to prevent the unwanted change of the slice name before running the "stop experiment" action
- w-iLab.t account password is taken from the configuration file (conf.txt), and the provisioner automatically writes it to action yaml files. This is done in order to homogenize w-iLab.t configuration on OpenBenchmark with IoT-LAB configuration
- `otbox-flash` value is substituted with `flash`, in all instances
- If firmware name is provided, the provisioner will use that firmware instead of the default one