### PR TITLE
Miscellaneous enhancements

### DIFF
--- a/conf.txt
+++ b/conf.txt
@@ -5,3 +5,9 @@ broker = broker.mqttdashboard.com
 [wilab]
 broker = broker.mqttdashboard.com
 password = YOUR_PASSWORD
+
+[dependencies]
+ov-repo = https://github.com/malishav/openvisualizer.git
+ov-branch = OV-7
+coap-repo = https://github.com/malishav/coap.git
+coap-branch = develop_COAP-44

--- a/experiment-orchestrator/kpi/processing.py
+++ b/experiment-orchestrator/kpi/processing.py
@@ -107,7 +107,7 @@ class KPIProcessing:
 	def _log_latency(self, payload, origin_packet):
 		# Log latency only if packet received before timeout
 		if origin_packet != None:
-			latency = payload['timestamp'] - origin_packet['timestamp']
+			latency = abs(payload['timestamp'] - origin_packet['timestamp'])
 			
 			self.logger.log('kpi', {
 					'kpi'         : 'latency',

--- a/experiment-orchestrator/kpi/processing.py
+++ b/experiment-orchestrator/kpi/processing.py
@@ -176,5 +176,5 @@ class KPIProcessing:
 				'eui64'    : event_obj['source'],
 				'node_id'  : Utils.eui64_to_id[event_obj['source']],
 				'timestamp': event_obj['timestamp'],
-				'value'    : event_obj['dutyCycle']
+				'value'    : float(event_obj['dutyCycle'].strip('%'))
 			}) 

--- a/experiment-orchestrator/kpi/processing.py
+++ b/experiment-orchestrator/kpi/processing.py
@@ -30,7 +30,12 @@ class KPIProcessing:
 		self.queue            = self.condition_object.exp_event_queue
 		self.queue_pck_drop   = self.condition_object.packet_drop_queue
 
-		self.buffer           = TimeoutBuffer(timeout=60)   # in seconds
+		# Buffer_1 - for buffering `packetSent` events
+		# Buffer_2 - for buffering `packetReceived` events
+		# Buffer_2 does not expire because packetReceived events should get their packetSent events eventually
+		self.buffer_1         = TimeoutBuffer(timeout=60, expire=True)   # in seconds
+		self.buffer_2         = TimeoutBuffer(timeout=60, expire=False)  # in seconds
+
 		self.packet_memory    = {'sent': {}, 'dropped': {}}   # { "sent": {"node_id": {"dest_node_id": `Int`}, "dropped": {...} }
 
 		self.event_to_method  = {

--- a/experiment-orchestrator/kpi/processing.py
+++ b/experiment-orchestrator/kpi/processing.py
@@ -136,13 +136,25 @@ class KPIProcessing:
 
 
 	def _packet_sent(self, payload):
-		self.buffer.put(payload)
-		self._increment('sent', payload['node_id'], payload['dest_node_id'])
+		# Check buffer_2 and calculate KPI if present. Otherwise, put in buffer_1
+		origin_packet = self.buffer_2.find(payload['packetToken'])
+		
+		if origin_packet != None:
+			self._log_latency(payload, origin_packet)
+			self._log_reliability(payload)
+		else:	
+			self.buffer_1.put(payload)
+			self._increment('sent', payload['node_id'], payload['dest_node_id'])
 
 	def _packet_received(self, payload):
-		origin_packet = self.buffer.find(payload['packetToken'])
-		self._log_latency(payload, origin_packet)
-		self._log_reliability(payload)
+		# Check buffer_1 and calculate KPI if present. Otherwise, put in buffer_2
+		origin_packet = self.buffer_1.find(payload['packetToken'])
+
+		if origin_packet != None:
+			self._log_latency(payload, origin_packet)
+			self._log_reliability(payload)
+		else:
+			self.buffer_2.put(payload)
 			
 	def _networkFormationTime(self, event_obj):
 		print str(event_obj)

--- a/experiment-orchestrator/kpi/timeout_buffer.py
+++ b/experiment-orchestrator/kpi/timeout_buffer.py
@@ -45,7 +45,7 @@ class TimeoutBuffer():
 
 	def find(self, packet_token):
 		token = ''.join(str(elem) for elem in packet_token)
-		if token != '' and self.buffer[token] != None:
+		if token != '' and token in self.buffer and self.buffer[token] != None:
 			packet = self.buffer[token]
 			self.buffer[token] = None
 			return packet

--- a/experiment-orchestrator/kpi/timeout_buffer.py
+++ b/experiment-orchestrator/kpi/timeout_buffer.py
@@ -8,10 +8,11 @@ from mqtt_client._condition_object import ConditionObject
 
 class TimeoutBuffer():
 
-	def __init__(self, timeout):
+	def __init__(self, timeout, expire=True):
 		self.timeout  = timeout
 		self.buffer   = {}
 		self.lock     = threading.Lock()
+		self.expire   = expire
 
 		self.condition_object = ConditionObject.create()
 		self.cv_packet_drop   = self.condition_object.packet_drop_cv
@@ -39,7 +40,8 @@ class TimeoutBuffer():
 		with self.lock:
 			token = ''.join(str(elem) for elem in item['packetToken'])
 			self.buffer[token] = item
-			threading.Timer(self.timeout, self._expire, [token]).start()
+			if self.expire:
+				threading.Timer(self.timeout, self._expire, [token]).start()
 
 	def find(self, packet_token):
 		token = ''.join(str(elem) for elem in packet_token)

--- a/experiment-orchestrator/mqtt_client/mqtt_client.py
+++ b/experiment-orchestrator/mqtt_client/mqtt_client.py
@@ -52,7 +52,8 @@ class MQTTClient:
 			"triggerNetworkFormation": "openbenchmark/experimentId/{0}/command/triggerNetworkFormation".format(self.experiment_id),
 			"notifications": "openbenchmark/{0}/notifications".format(Utils.user_id),
 			"kpi": "openbenchmark/{0}/kpi".format(Utils.user_id),
-			"raw": "openbenchmark/{0}/raw".format(Utils.user_id)
+			"raw": "openbenchmark/{0}/raw".format(Utils.user_id),
+			"debug": "openbenchmark/{0}/debug".format(Utils.user_id)
 		}
 		self.epe_sub_topics = {  # Experiment Performance Events
 			"performanceData": "openbenchmark/experimentId/{0}/nodeId/+/performanceData".format(self.experiment_id)
@@ -219,4 +220,4 @@ class MQTTClient:
 			"log_entry": log_entry
 		})
 		if console_print:
-			print("{0} {1}".format(action, message))
+			print("{0} {1}".format(action, log_entry))

--- a/experiment-orchestrator/mqtt_client/mqtt_client.py
+++ b/experiment-orchestrator/mqtt_client/mqtt_client.py
@@ -212,3 +212,11 @@ class MQTTClient:
 			"type": "raw",
 			"content": payload
 		})
+
+	def push_debug_log(self, action, log_entry, console_print = True):
+		self.publish("debug", {
+			"action": action,
+			"log_entry": log_entry
+		})
+		if console_print:
+			print("{0} {1}".format(action, message))

--- a/experiment-orchestrator/network_prep.py
+++ b/experiment-orchestrator/network_prep.py
@@ -64,6 +64,7 @@ class NetworkPrep:
 				raise Exception("Failed to trigger network formation. Exiting...")
 				self.mqtt_client.push_notification("network-configured", False)
 
+			self.mqtt_client.push_debug_log("[NETWORK PREP]", "Network formation triggered successfully", False)
 			sys.stdout.write("{0}[NETWORK PREP] {1}\n{2}".format(
 				colorama.Fore.GREEN,
 				"Network formation triggered successfully", 
@@ -71,6 +72,7 @@ class NetworkPrep:
 			))
 		
 		except Exception, e:
+			self.mqtt_client.push_debug_log("[NETWORK PREP]", "Exception - {0}".format(str(e)), False)
 			sys.stdout.write("{0}[NETWORK PREP] {1}\n{2}".format(
 				colorama.Fore.RED,
 				str(e), 

--- a/experiment-orchestrator/scheduler.py
+++ b/experiment-orchestrator/scheduler.py
@@ -77,7 +77,7 @@ class Scheduler:
 	def _print_schedule(self):
 		schedule_len = len(self.schedule)
 
-		print "[SCHEDULER] Starting schedule:"
+		self.mqtt_client.push_debug_log("[SCHEDULER]", "Starting schedule:")
 		for i in range(0, schedule_len):
 			print "{0} at {1}: from {2} to {3}".format(
 				self.schedule[i]["node"].node_id, 
@@ -91,6 +91,7 @@ class Scheduler:
 
 	def _start_schedule(self):
 		schedule_len = self._print_schedule()
+		self.mqtt_client.push_debug_log("[SCHEDULER]", "Starting scheduler in {0} seconds...\n".format(self.scheduler_delay), False)
 		sys.stdout.write("[SCHEDULER] Starting scheduler in {0} seconds...\n".format(self.scheduler_delay))
 		time.sleep(self.scheduler_delay)
 
@@ -115,7 +116,9 @@ class Scheduler:
 				})
 
 			if sleep_interval == -1:
+				self.mqtt_client.push_debug_log("[SCHEDULER]", "Currently on: {0}/{1}. Last event\n".format(i+1, schedule_len), False)
 				sys.stdout.write("[SCHEDULER] Currently on: {0}/{1}. Last event\n".format(i+1, schedule_len))
 			else:
+				self.mqtt_client.push_debug_log("[SCHEDULER]", "Currently on: {0}/{1}. Last event\n".format(i+1, schedule_len), False)
 				sys.stdout.write("[SCHEDULER] Currently on: {0}/{1}. Next event in {2} seconds\n".format(i+1, schedule_len, sleep_interval))
 				time.sleep(sleep_interval)

--- a/experiment-provisioner/fw_compiler.py
+++ b/experiment-provisioner/fw_compiler.py
@@ -21,55 +21,88 @@ class FWCompiler:
 			"iotlab" : "iot-lab_A8-M3",
 			"wilab"  : "remote" 
 		}
+		self.fw_dir      = os.path.join(os.path.dirname(__file__), "firmware") 
 
 	def compile(self):
 		self._clone_branch()
-		fw_name = self._compile_fw()
-		self._move_fw(fw_name)
-		self._delete_branch()
+		self._compile_fw()
+		fw_name = self._move_fw()
+		self._delete_repo()
 
 		return fw_name
 
 
 	def _clone_branch(self):
-		self.mqtt_client.push_debug_log('FW_COMPILATION', 'Cloning the branch...')
-		print("[FW_COMPILATION] Cloning the branch...")
-		clone_fw_repo = "git clone -b {0} --single-branch {1}".format(self.branch, self.repo_url)
-		subprocess.Popen(clone_fw_repo, shell=True)		
+		self._print_log('Cloning the branch...')
+		self._run_cmd('clone')
 
 	def _compile_fw(self):
+		self._print_log('Compiling firmware...')
+		self._run_cmd('compile')
+
+	def _move_fw(self):
+		self._print_log('Renaming and moving firmware...')
 		fw_name = self._generate_random_fw_name()
-		pipe = subprocess.Popen(['scons', 'board={0}'.format(self.board_names[self.testbed]), 'toolchain=armgcc', 'apps=cbenchmark', ], 
-				cwd=self.local_repo, 
-				stdin=subprocess.PIPE,
-				stderr=subprocess.PIPE, 
-				stdout=subprocess.PIPE
-			)
+		
+		compiled_fw_path = os.path.join(self.local_repo, 'build', '{0}_armgcc'.format(self.board_names[self.testbed]), 'projects', 'common', '03oos_openwsn_prog')
+		move_to_location = os.path.join(self.fw_dir, fw_name)
 
-        for line in iter(pipe.stdout.readline, b''):
-            output = line.rstrip()
-            print(">>> " + output)
-            self.mqtt_client.push_debug_log('FW_COMPILATION', output)
+		print self.fw_dir
+		print fw_name
+		print compiled_fw_path
+		print move_to_location
 
-        for line in iter(pipe.stderr.readline, b''):
-            output = line.rstrip()
-            print(">>> " + output)
-            self.mqtt_client.push_debug_log('FW_COMPILATION [ERROR]', output)
+		mv_cmd = "mv {0} {1}".format(compiled_fw_path, move_to_location)
+		subprocess.Popen(mv_cmd, shell=True)
 
-	def _delete_branch(self):
-		self.mqtt_client.push_debug_log('FW_COMPILATION', 'Removing the cloned repo...')
-		print("[FW_COMPILATION] Removing the cloned repo...")
-		del_dir = "rm -rf {0}".format(self.repo_name)
+		self._print_log('')
+		self._print_log('')
+		self._print_log('')
+		self._print_log('Firmware moved to a new location: {0}'.format(move_to_location))
+
+		return fw_name
+
+	def _delete_repo(self):
+		self._print_log('Removing the cloned repo...')
+		del_dir = "rm -rf {0}".format( os.path.join(os.path.dirname(__file__), self.repo_name) )
 		subprocess.Popen(del_dir, shell=True)
 
+
+	def _run_cmd(self, cmd):
+		cmds = {
+			"clone"   : ['git', 'clone', '-b', self.branch, '--single-branch', self.repo_url],
+			"compile" : ['scons', 'board={0}'.format(self.board_names[self.testbed]), 'toolchain=armgcc', 'apps=cbenchmark', 'oos_openwsn']
+		}
+
+		cwds = {
+			"clone"   : os.path.dirname(os.path.abspath(__file__)),
+			"compile" : self.local_repo
+		}
+
+		pipe = subprocess.Popen(cmds[cmd], cwd=cwds[cmd], stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+		
+		for line in iter(pipe.stdout.readline, b''):
+			output = line.rstrip()
+			self._print_log(output)
+			
+		for line in iter(pipe.stderr.readline, b''):
+			output = line.rstrip()
+			self._print_log(output)
+
+
 	def _get_repo_name(self):
-		url_split = self.url.split('/')
+		url_split = self.repo_url.split('/')
 		return url_split[len(url_split) - 1].split('.')[0]
 
 	def _generate_random_fw_name(self):
 		letters = string.ascii_lowercase
-		suffix  = ''.join(random.choice(letters) for i in range(10))
+		suffix  = ''.join(random.choice(letters) for i in range(7))
 		return "{0}_{1}_{2}".format(self.repo_name, self.branch, suffix)
+
+	def _print_log(self, message):
+		self.mqtt_client.push_debug_log("[FW_COMPILATION]", message)
+		print("[FW_COMPILATION] {0}".format(message))
+
 
 def main():
 	FWCompiler(

--- a/experiment-provisioner/fw_compiler.py
+++ b/experiment-provisioner/fw_compiler.py
@@ -70,3 +70,14 @@ class FWCompiler:
 		letters = string.ascii_lowercase
 		suffix  = ''.join(random.choice(letters) for i in range(10))
 		return "{0}_{1}_{2}".format(self.repo_name, self.branch, suffix)
+
+def main():
+	FWCompiler(
+		repo_url = 'https://github.com/malishav/openwsn-fw.git',
+		branch   = 'develop_FW-808',
+		testbed  = 'iotlab',
+		user_id  = 1
+	).compile()
+
+if __name__ == '__main__':
+	main()

--- a/experiment-provisioner/fw_compiler.py
+++ b/experiment-provisioner/fw_compiler.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import random
+import string
+
+from mqtt_client import MQTTClient
+
+
+class FWCompiler:
+
+	def __init__(self, repo_url, branch, testbed, user_id):
+		self.repo_url    = repo_url
+		self.branch      = branch
+		self.repo_name   = self._get_repo_name()
+		self.testbed     = testbed
+		self.user_id     = user_id  
+		self.local_repo  = os.path.join(os.path.dirname(__file__), self.repo_name)
+		self.mqtt_client = MQTTClient.create(testbed, user_id)
+
+		self.board_names = {
+			"iotlab" : "iot-lab_A8-M3",
+			"wilab"  : "remote" 
+		}
+
+	def compile(self):
+		self._clone_branch()
+		fw_name = self._compile_fw()
+		self._move_fw(fw_name)
+		self._delete_branch()
+
+		return fw_name
+
+
+	def _clone_branch(self):
+		self.mqtt_client.push_debug_log('FW_COMPILATION', 'Cloning the branch...')
+		print("[FW_COMPILATION] Cloning the branch...")
+		clone_fw_repo = "git clone -b {0} --single-branch {1}".format(self.branch, self.repo_url)
+		subprocess.Popen(clone_fw_repo, shell=True)		
+
+	def _compile_fw(self):
+		fw_name = self._generate_random_fw_name()
+		pipe = subprocess.Popen(['scons', 'board={0}'.format(self.board_names[self.testbed]), 'toolchain=armgcc', 'apps=cbenchmark', ], 
+				cwd=self.local_repo, 
+				stdin=subprocess.PIPE,
+				stderr=subprocess.PIPE, 
+				stdout=subprocess.PIPE
+			)
+
+        for line in iter(pipe.stdout.readline, b''):
+            output = line.rstrip()
+            print(">>> " + output)
+            self.mqtt_client.push_debug_log('FW_COMPILATION', output)
+
+        for line in iter(pipe.stderr.readline, b''):
+            output = line.rstrip()
+            print(">>> " + output)
+            self.mqtt_client.push_debug_log('FW_COMPILATION [ERROR]', output)
+
+	def _delete_branch(self):
+		self.mqtt_client.push_debug_log('FW_COMPILATION', 'Removing the cloned repo...')
+		print("[FW_COMPILATION] Removing the cloned repo...")
+		del_dir = "rm -rf {0}".format(self.repo_name)
+		subprocess.Popen(del_dir, shell=True)
+
+	def _get_repo_name(self):
+		url_split = self.url.split('/')
+		return url_split[len(url_split) - 1].split('.')[0]
+
+	def _generate_random_fw_name(self):
+		letters = string.ascii_lowercase
+		suffix  = ''.join(random.choice(letters) for i in range(10))
+		return "{0}_{1}_{2}".format(self.repo_name, self.branch, suffix)

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -15,6 +15,7 @@ from reservation import WilabReservation
 
 from otbox_flash import OTBoxFlash
 from ov_startup import OVStartup
+from fw_compiler import FWCompiler
 
 
 class Controller(object):
@@ -301,6 +302,7 @@ TESTBEDS = {
 	"wilab": Wilab
 }
 
+
 def main():
 	controller = Controller()
 
@@ -312,13 +314,16 @@ def main():
 	testbed   = args['testbed']
 	scenario  = args['scenario']
 
+	firmware  = args['firmware']
+	branch    = args['branch']
+
 	testbed  = TESTBEDS[testbed](user_id, scenario, action)
 
 	# Default firmware is "openwsn" with testbed name suffix
-	if args['firmware'] is None:
+	if firmware is None:
 		firmware = os.path.join(os.path.dirname(__file__), 'firmware', controller.DEFAULT_FIRMWARE + '.' + args['testbed'])
-	else:
-		firmware = args['firmware']
+	elif branch is not None:
+		firmware = FWCompiler(firmware, branch, testbed, user_id).compile()
 
 	if action == 'reserve':
 		print 'Reserving nodes'

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -29,6 +29,11 @@ class Controller(object):
 		self.configParser = ConfigParser.RawConfigParser()   
 		self.configParser.read(self.CONFIG_FILE)
 
+		self.OV_REPO     = self.configParser.get('dependencies', 'ov-repo')
+		self.OV_BRANCH   = self.configParser.get('dependencies', 'ov-branch')
+		self.COAP_REPO   = self.configParser.get('dependencies', 'coap-repo')
+		self.COAP_BRANCH = self.configParser.get('dependencies', 'coap-branch')
+
 	def add_parser_args(self, parser):
 		self.default_fws = {
 			"iotlab": "03oos_openwsn_prog_iotlab",
@@ -340,7 +345,17 @@ def main():
 		OTBoxFlash(user_id, firmware, testbed.BROKER, args['testbed']).flash()
 	elif action == 'ov-start':
 		print 'Starting OV'
-		OVStartup(user_id, scenario, args['testbed'], testbed.BROKER, simulator).start()
+		OVStartup(
+			user_id, 
+			scenario, 
+			args['testbed'], 
+			testbed.BROKER, 
+			simulator, 
+			testbed.OV_REPO, 
+			testbed.OV_BRANCH, 
+			testbed.COAP_REPO,
+			testbed.COAP_BRANCH
+		).start()
 
 if __name__ == '__main__':
 	main()

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -62,6 +62,11 @@ class Controller(object):
 			required   = False,
 			action     = 'store',
 		)
+		parser.add_argument('--branch', 
+			dest       = 'branch',
+			required   = False,
+			action     = 'store',
+		)
 		parser.add_argument('--scenario', 
 			dest       = 'scenario',
 			choices    = ['demo-scenario', 'building-automation', 'home-automation', 'industrial-monitoring'],
@@ -80,6 +85,7 @@ class Controller(object):
 			'action'    : args.action,
 			'testbed'   : args.testbed,
 			'firmware'  : args.firmware,
+			'branch'    : args.branch,
 			'scenario'  : args.scenario
 		}
 

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -95,6 +95,16 @@ class Controller(object):
 			'scenario'  : args.scenario
 		}
 
+	def _get_duration(self, scenario):
+		config_file = os.path.join(self.SCENARIO_CONFIG, scenario, "_config.json")
+		duration_min = -1
+
+		with open(config_file, 'r') as f:
+			config_obj = json.load(f)
+			duration_min = config_obj['duration_min']
+
+		return duration_min
+
 	@abstractmethod
 	def add_files_from_env(self):
 		pass
@@ -112,8 +122,8 @@ class IoTLAB(Controller):
 		self.PRIVATE_SSH = os.environ["private_ssh"] if "private_ssh" in os.environ else ""
 		self.HOSTNAME = 'saclay.iot-lab.info'
 
-		self.EXP_DURATION = 30 # Duration in minutes
 		self.NODES = self._get_nodes()
+		self.EXP_DURATION = self._get_duration(self.scenario) + 10
 
 		self.BROKER = self.configParser.get(self.CONFIG_SECTION, 'broker')
 
@@ -142,6 +152,7 @@ class IoTLAB(Controller):
 			return nodes_str.rstrip("+")
 
 
+
 class Wilab(Controller):
 
 	def __init__(self, user_id, scenario, action):
@@ -167,7 +178,7 @@ class Wilab(Controller):
 		self.BROKER   = self.configParser.get(self.CONFIG_SECTION, 'broker')
 		self.PASSWORD = self.configParser.get(self.CONFIG_SECTION, 'password')
 
-		self.EXP_DURATION = 30
+		self.EXP_DURATION = self._get_duration(self.scenario) + 10
 
 		self._rspec_update()
 		self._set_broker()

--- a/experiment-provisioner/ov_startup.py
+++ b/experiment-provisioner/ov_startup.py
@@ -72,6 +72,7 @@ class OVStartup:
 		subprocess.Popen(coap_del_dir, shell=True)
 
 	def _clone_dependencies(self):
+		self._print_log('Cloning dependencies...')
 		self._run_cmd('ov-clone')
 		self._run_cmd('coap-clone')
 

--- a/experiment-provisioner/ov_startup.py
+++ b/experiment-provisioner/ov_startup.py
@@ -66,10 +66,8 @@ class OVStartup:
 
 	def _delete_dependencies(self):
 		self._print_log('Removing dependencies...')
-		ov_del_dir = "rm -rf {0}".format(ov_dir)
-		coap_del_dir = "rm -rf {0}".format(coap_dir)
-		subprocess.Popen(ov_del_dir, shell=True)
-		subprocess.Popen(coap_del_dir, shell=True)
+		self._run_cmd('ov-delete')
+		self._run_cmd('coap-delete')
 
 	def _clone_dependencies(self):
 		self._print_log('Cloning dependencies...')
@@ -77,16 +75,12 @@ class OVStartup:
 		self._run_cmd('coap-clone')
 
 	def _run_cmd(self, cmd):
-		repos = {
-			"ov-clone"  : self.ov_repo
-			"coap-clone": self.coap_repo
-		}
-		branches = {
-			"ov-clone"  : self.ov_branch
-			"coap-clone": self.coap_branch
-		}
-
-		cmd = ['git', 'clone', '-b', branches[cmd], '--single-branch', repos[cmd]]
+		cmds = {
+			"ov-clone"   : ['git', 'clone', '-b', self.ov_branch, '--single-branch', self.ov_repo],
+			"coap-clone" : ['git', 'clone', '-b', self.coap_branch, '--single-branch', self.coap_repo],
+			"ov-delete"  : ['sudo', 'rm', '-rf', ov_dir], 
+			"coap-delete": ['sudo', 'rm', '-rf', coap_dir]
+		}	
 
 		pipe = subprocess.Popen(cmds[cmd], cwd=openwsn_dir, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 		

--- a/experiment-provisioner/ov_startup.py
+++ b/experiment-provisioner/ov_startup.py
@@ -29,7 +29,7 @@ class OVStartup:
 		if self.simulator:
 			self._start_orchestrator()
 		else:
-			self._clone_dependencies()
+			self._load_dependencies()
 
 			thread_orch = threading.Thread(target=self._start_ov)
 			thread_orch.start()

--- a/experiment-provisioner/reservation.py
+++ b/experiment-provisioner/reservation.py
@@ -111,6 +111,7 @@ class IoTLABReservation(Reservation):
                 if len(nodes) > 0:
                     OTBoxStartup(self.user, self.domain, 'iotlab', self.get_reserved_nodes(), self.broker, self.mqtt_client).start()
                 else:
+                    self.mqtt_client.push_debug_log('RESERVATION_FAIL', 'Experiment startup failed')
                     print('Experiment startup failed')
 
     def check_experiment(self, loop=False):
@@ -183,7 +184,7 @@ class WilabReservation(Reservation):
         for line in iter(pipe.stderr.readline, b''):
             output = line.rstrip()
             print(">>> " + output)
-            self.mqtt_client.push_debug_log('WILAB_PROVISIONING', output)
+            self.mqtt_client.push_debug_log('WILAB_PROVISIONING [ERROR]', output)
 
     def _start_display(self):
         pipe = subprocess.Popen(['xrandr', '-d', ':99'], stdin=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/web/resources/assets/js/components/charts/LineChart.vue
+++ b/web/resources/assets/js/components/charts/LineChart.vue
@@ -15,7 +15,8 @@
             return {
                 titles: {
                     "latency": "Latency",
-                    "reliability": "Reliability"
+                    "reliability": "Reliability",
+                    "radioDutyCycle": "Duty Cycle"
                 }
             }
         },


### PR DESCRIPTION
This PR introduces the following enhancements:

- If Git repo URL is given with `--firmware` parameter (instead of a firmware name), Provisioner looks for the branch name in `--branch` parameter, clones that branch, and compiles the cloned firmware source code
- Additional Provisioner and Orchestrator steps are logged and sent as a debug entry over MQTT. The logging is added to Provisioner's entry point and Orchestrator's `main.py`, `network_prep.py` and `scheduler.py`
- The exact OpenVisualizer's and Coap's repo url and branch are specified within the OpenBenchmark conf file. Prior to every OpenVisualizer start-up with `ov-start` action, OpenVisualizer and Coap are cloned from their respective repos
- Due to the cases where `packetReceived` event arrives before its respective `packetSent` event, a new buffer and an enhanced `packetReceived/Sent` event processing mechanism has been introduced with the purpose of storing the early `packetReceived` events and calculating a KPI value only when its respective `packetSent` event arrives
- Experiment duration time is loaded from scenario configuration files. Additionally, a temporary 10 minutes time padding has been added to cover for the resource provisioning, firmware flashing, and network configuration process