### PR TITLE
Enh/otb clone

### DIFF
--- a/conf.txt
+++ b/conf.txt
@@ -11,3 +11,5 @@ ov-repo = https://github.com/malishav/openvisualizer.git
 ov-branch = OV-7
 coap-repo = https://github.com/malishav/coap.git
 coap-branch = develop_COAP-44
+otb-repo = https://github.com/openwsn-berkeley/opentestbed.git
+otb-tag = REL-1.2.3

--- a/experiment-provisioner/helpers/iotlab/otbox_startup.py
+++ b/experiment-provisioner/helpers/iotlab/otbox_startup.py
@@ -59,7 +59,7 @@ class OTBoxStartup:
 
         # Fetch the latest version of opentestbed software in the shared A8 director of the SSH frontend
         self.ssh_command_exec(
-            'cd A8; rm -rf opentestbed; git clone https://github.com/bozidars27/opentestbed.git; cd opentestbed; git checkout origin/opentestbed-extension;')
+            'cd A8; rm -rf opentestbed; git clone {0}; cd opentestbed; git fetch --tags; git checkout {1};'.format(self.otb_repo, self.otb_tag))
 
     def ssh_connect(self):
         self.client.connect(self.domain, username=self.user)

--- a/experiment-provisioner/helpers/iotlab/otbox_startup.py
+++ b/experiment-provisioner/helpers/iotlab/otbox_startup.py
@@ -26,7 +26,7 @@ class OTBoxStartup:
 
     timer = 0  # used for measuring the amount of time between status messages
 
-    def __init__(self, user, domain, testbed, nodes, broker, mqtt_client):
+    def __init__(self, user, domain, testbed, nodes, broker, mqtt_client, otb_repo, otb_tag):
         warnings.simplefilter(
             action='ignore',
             category=CryptographyDeprecationWarning
@@ -37,6 +37,9 @@ class OTBoxStartup:
         self.testbed     = testbed
         self.broker      = broker
         self.mqtt_client = mqtt_client
+
+        self.otb_repo  = otb_repo
+        self.otb_tag   = otb_tag
 
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/experiment-provisioner/main.py
+++ b/experiment-provisioner/main.py
@@ -35,6 +35,8 @@ class Controller(object):
 		self.OV_BRANCH   = self.configParser.get('dependencies', 'ov-branch')
 		self.COAP_REPO   = self.configParser.get('dependencies', 'coap-repo')
 		self.COAP_BRANCH = self.configParser.get('dependencies', 'coap-branch')
+		self.OTB_REPO    = self.configParser.get('dependencies', 'otb-repo')
+		self.OTB_TAG     = self.configParser.get('dependencies', 'otb-tag')
 
 	def add_parser_args(self, parser):
 		self.default_fws = {
@@ -134,7 +136,7 @@ class IoTLAB(Controller):
 		self.BROKER = self.configParser.get(self.CONFIG_SECTION, 'broker')
 
 		self.add_files_from_env()
-		self.reservation = IoTLABReservation(user_id, self.USERNAME, self.HOSTNAME, self.BROKER, self.EXP_DURATION, self.NODES)
+		self.reservation = IoTLABReservation(user_id, self.USERNAME, self.HOSTNAME, self.BROKER, self.OTB_REPO, self.OTB_TAG, self.EXP_DURATION, self.NODES)
 
 		self.mqtt_client = MQTTClient.create('iotlab', user_id)
 

--- a/experiment-provisioner/reservation.py
+++ b/experiment-provisioner/reservation.py
@@ -32,7 +32,7 @@ class IoTLABReservation(Reservation):
     SSH_RETRY_TIME = 120
     RETRY_PAUSE = 10
 
-    def __init__(self, user_id, user, domain, broker, duration=None, nodes=None):
+    def __init__(self, user_id, user, domain, broker, otb_repo, otb_tag, duration=None, nodes=None):
         warnings.simplefilter(
             action='ignore',
             category=CryptographyDeprecationWarning
@@ -45,6 +45,9 @@ class IoTLABReservation(Reservation):
         self.duration = duration
         self.nodes    = nodes
         self.broker   = broker
+
+        self.otb_repo = otb_repo
+        self.otb_tag  = otb_tag
 
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/experiment-provisioner/reservation.py
+++ b/experiment-provisioner/reservation.py
@@ -112,7 +112,7 @@ class IoTLABReservation(Reservation):
                 nodes = self.get_reserved_nodes()
 
                 if len(nodes) > 0:
-                    OTBoxStartup(self.user, self.domain, 'iotlab', self.get_reserved_nodes(), self.broker, self.mqtt_client).start()
+                    OTBoxStartup(self.user, self.domain, 'iotlab', self.get_reserved_nodes(), self.broker, self.mqtt_client, self.otb_repo, self.otb_tag).start()
                 else:
                     self.mqtt_client.push_debug_log('RESERVATION_FAIL', 'Experiment startup failed')
                     print('Experiment startup failed')


### PR DESCRIPTION
This PR adds logic for dynamically creating a set of commands for cloning Opentestbed on each IoT-LAB A8 node, after every successful resource provisioning. Opentestbed repository URL and tag parameters that are provided to `OTBoxStartup` class are loaded from the conf file