### PR TITLE
Independent Orchestrator and OpenVisualizer startup

### DIFF
--- a/experiment_provisioner/main.py
+++ b/experiment_provisioner/main.py
@@ -13,7 +13,7 @@ from reservation import IoTLABReservation
 from reservation import WilabReservation
 
 from otbox_flash import OTBoxFlash
-from ov_startup import OVStartup
+from sut_startup import SUTStartup
 from fw_compiler import FWCompiler
 
 from mqtt_client import MQTTClient
@@ -296,14 +296,16 @@ class Main():
 			assert firmware is not None
 			testbedCtl.print_log('Flashing firmware: {0}'.format(firmware))
 			OTBoxFlash(user_id, firmware, testbedCtl.BROKER, testbed).flash()
-		elif action == 'ov-start':
+		elif action == 'sut-start' or action == 'orchestrator' or action == 'ov':
 			testbedCtl.print_log('Starting SUT...')
-			OVStartup(
+			SUTStartup(
 				user_id, 
 				scenario, 
 				testbed, 
 				testbedCtl.BROKER, 
-				simulator, 
+				simulator,
+				action == 'orchestrator',
+				action == 'ov', 
 				testbedCtl.OV_REPO, 
 				testbedCtl.OV_BRANCH, 
 				testbedCtl.COAP_REPO,

--- a/experiment_provisioner/test/mqttTest.py
+++ b/experiment_provisioner/test/mqttTest.py
@@ -14,9 +14,9 @@ class MQTTTest:
 		self.client.on_message = self.on_message
 
 		self.pauses = {
-			"reserve":      5,
-			"flash": 50,
-			"ov-start":   180 
+			"reserve"  :   5,
+			"flash"    :  50,
+			"sut-start": 180 
 		}
 
 		self.pause = self.pauses[self.test_type] if self.test_type in self.pauses else 5
@@ -30,8 +30,8 @@ class MQTTTest:
 		if self.test_type in ['reserve', 'flash']:
 			self.client.subscribe('{0}/deviceType/mote/deviceId/+/notif/frommoteserialbytes'.format(self.testbed))
 			print "[TEST] flash subscribing..."
-		elif self.test_type == 'ov-start':
-			print "[TEST] ov-start subscribing..."
+		elif self.test_type == 'sut-start':
+			print "[TEST] sut-start subscribing..."
 			self.client.subscribe('openbenchmark/command/startBenchmark')
 
 	def on_message(self, client, userdata, message):

--- a/experiment_provisioner/test/test.py
+++ b/experiment_provisioner/test/test.py
@@ -23,4 +23,4 @@ def test_firmware_flash():
 	assert general_test('flash')
 
 def test_ov_start():
-	assert general_test('ov-start')
+	assert general_test('sut-start')

--- a/experiment_provisioner/test/testbed.py
+++ b/experiment_provisioner/test/testbed.py
@@ -18,7 +18,7 @@ class Testbed():
 	def run_action(self, action):
 		self.delay(action)
 
-		if (action != 'ov-start'):
+		if (action != 'sut-start'):
 			pipe = subprocess.Popen(['python', 'openbenchmark.py', '--action={0}'.format(action), '--user-id=1'], cwd=self.mainDir, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 			res = pipe.communicate()
 
@@ -36,7 +36,7 @@ class Testbed():
 
 
 	def delay(self, action):
-		if action == 'ov-start':
+		if action == 'sut-start':
 			time.sleep(self.OV_START_PAUSE)
 		elif action == 'check':
 			time.sleep(self.EXP_CHECK_PAUSE)
@@ -47,7 +47,7 @@ class Testbed():
 			return self.reserve(return_code, stdout, stderr)
 		elif action == 'flash':
 			return self.flash(return_code, stdout, stderr)
-		elif action == 'ov-start':
+		elif action == 'sut-start':
 			return self.ov_start(return_code, stdout, stderr)
 		elif action == 'check':
 			return self.exp_check(return_code, stdout, stderr)
@@ -85,5 +85,5 @@ class IoTLAB(Testbed):
 		return return_code == 0 and stderr == '' and mqttTest.check_data()
 
 	def ov_start(self, return_code, stdout, stderr):
-		mqttTest = MQTTTest('iotlab', 'ov-start')
+		mqttTest = MQTTTest('iotlab', 'sut-start')
 		return return_code == 0 and stderr == '' and mqttTest.check_data()

--- a/openbenchmark.py
+++ b/openbenchmark.py
@@ -20,7 +20,7 @@ class OpenBenchmark:
 		)
 		parser.add_argument('--action', 
 			dest       = 'action',
-			choices    = ['check', 'reserve', 'terminate', 'flash', 'ov-start'],
+			choices    = ['check', 'reserve', 'terminate', 'flash', 'sut-start', 'ov', 'orchestrator'],
 			required   = True,
 			action     = 'store'
 		)

--- a/openbenchmark.py
+++ b/openbenchmark.py
@@ -52,6 +52,8 @@ class OpenBenchmark:
 		self.add_parser_args(parser)
 		args = parser.parse_args()
 
+		self._validate(args, parser)
+
 		return {
 			'user_id'   : args.user_id,
 			'simulator' : args.simulator,
@@ -61,6 +63,10 @@ class OpenBenchmark:
 			'branch'    : args.branch,
 			'scenario'  : args.scenario
 		}
+
+	def _validate(self, args, parser):
+		if args.action != 'sut-start' and args.simulator:
+			parser.error('--simulator is only a valid parameter for --action=sut-start')
 
 
 def main():

--- a/readme.md
+++ b/readme.md
@@ -42,14 +42,50 @@ vagrant ssh
 ./openbenchmark/bootstrap_webdev.sh -mysql
 ```
 
-4. Write your IoT-LAB username into the experiment configuration file: `~/openbenchmark/experiment_provisioner/conf.txt`
+5. Write your IoT-LAB username into the experiment configuration file: `~/openbenchmark/experiment_provisioner/conf.txt`
 ```
 [iotlab-config]
 user = YOUR_USER_NAME
 broker = broker.mqttdashboard.com
 ```
 
-5. To start the GUI, open a web browser and go to `127.0.0.1:8081`. To start an experiment from the console, SSH into the server and refer to the documentation given with the OpenBenchmark platform: `http://127.0.0.1:8081/docs/#experiment_provisioner`
+6. To start the GUI, open a web browser and go to `127.0.0.1:8081`. Alternatively, you can start an experiment from the console.
+
+
+## Starting an experiment via console
+
+Workflow:
+
+1. Resource provisioning:
+```
+python openbenchmark.py --action=reserve --scenario=YOUR_SCENARIO --testbed=YOUR_TESTBED
+```
+
+2. Firmware flashing:
+```
+python openbenchmark.py --action=flash --firmware=YOUR_FIRMWARE/REPO_URL --testbed=YOUR_TESTBED [--branch=REPO_BRANCH]
+```
+If `--firmware` is not specified, Provisioner will assume the default OpenWSN firmware
+If parameter `--branch` is specified along with `--firmware`, Provisioner will treat the value of `--firmware` parameter as a URL of a Git repository, clone the repository, compile the source code and flash that firmware onto the nodes of the selected testbed
+ 
+3. SUT start:
+```
+python openbenchmark.py --action=sut-start --scenario=YOUR_SCENARIO --testbed=YOUR_TESTBED
+```
+
+Additional actions:
+
+- Independent Orchestrator startup:
+```
+python openbenchmark.py --action=orchestrator
+```
+
+- Independent OpenVisualizer startup:
+```
+python openbenchmark.py --action=ov --scenario=YOUR_SCENARIO --testbed=YOUR_TESTBED
+```
+
+If `--scenario` and `--testbed` parameters are not provided they will assume the default value of `demo-scenario` and `iotlab`, respectively
 
 
 ## Development


### PR DESCRIPTION
This PR allows two additional values to be specified as the values of `--action` parameter: `orchestrator` and `ov`, which independently start Orchestrator and OpenVisualizer, respectively. These values are not part of the regular OpenBenchmark workflow and are intended to be used for debugging and development. Additionally, this PR updates `readme.md` with the latest specifications of the OpenBenchmark console commands.