### PR TITLE
Issue #94: Use malishav fork of opentestbed software when bootstrapping.

### DIFF
--- a/bootstrap_jfed.sh
+++ b/bootstrap_jfed.sh
@@ -47,7 +47,7 @@ rm -rf jfed_cli
 
 # Opentestbed ESPEC clone
 if [ ! -d "opentestbed" ]; then
-	git clone -b espec --single-branch https://github.com/twalcari/opentestbed.git
+	git clone -b espec --single-branch https://github.com/malishav/opentestbed.git
 fi
 
 # jFed proxy configuration


### PR DESCRIPTION
This one-line PR switches from twalcari's opentestbed for to malishav in order to have control over the changes necessary to support OpenWSN when running in wilabt testbed.