### PR TITLE
Separating several KPIs per node

### DIFF
--- a/experiment_orchestrator/kpi/processing.py
+++ b/experiment_orchestrator/kpi/processing.py
@@ -158,8 +158,11 @@ class KPIProcessing:
 			
 	def _networkFormationTime(self, event_obj):
 		print str(event_obj)
+		print json.dumps(Utils.eui64_to_id)
 		self.logger.log('kpi', {
 				'kpi'      : 'networkFormationTime',
+				'node_id'  : Utils.eui64_to_id[event_obj['source']],
+				'eui64'    : event_obj['source'],
 				'timestamp': event_obj['timestamp'],
 				'value'    : 1
 			})
@@ -167,6 +170,8 @@ class KPIProcessing:
 	def _synchronizationPhase(self, event_obj):
 		self.logger.log('kpi', {
 				'kpi'      : 'syncronizationPhase',
+				'node_id'  : Utils.eui64_to_id[event_obj['source']],
+				'eui64'    : event_obj['source'],
 				'timestamp': event_obj['timestamp'],
 				'value'    : 1
 			})
@@ -174,6 +179,8 @@ class KPIProcessing:
 	def _secureJoinPhase(self, event_obj):
 		self.logger.log('kpi', {
 				'kpi'      : 'secureJoinPhase',
+				'node_id'  : Utils.eui64_to_id[event_obj['source']],
+				'eui64'    : event_obj['source'],
 				'timestamp': event_obj['timestamp'],
 				'value'    : 1
 			})

--- a/experiment_orchestrator/sut_simulator/simulator.py
+++ b/experiment_orchestrator/sut_simulator/simulator.py
@@ -140,6 +140,9 @@ class Simulator(object):
         if event == Events.radioDutyCycleMeasurement:
             sut_event_payload["dutyCycle"] = random.uniform(0, 1)
 
+        elif event == Events.networkFormationCompleted:
+            sut_event_payload["source"] = '00-12-4b-00-14-b5-b6-10'   # First node chosen as DAG root
+
         elif event in [Events.packetSent, Events.packetReceived]:
             if event == Events.packetSent:
                 if random.randint(1, 10) % 3 != 0:   # Simulate packet drop with probability of 0.3

--- a/experiment_provisioner/main.py
+++ b/experiment_provisioner/main.py
@@ -6,6 +6,7 @@ import yaml
 import string
 import random
 import subprocess
+import atexit
 
 from lxml import etree
 from abc import abstractmethod
@@ -24,7 +25,6 @@ class Controller(object):
 	CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "conf.txt")
 	SCENARIO_CONFIG = os.path.join(os.path.dirname(__file__), "..", "scenario-config")
 	DEFAULT_FIRMWARE = '03oos_openwsn_prog'
-
 
 	def __init__(self):
 		self.configParser = ConfigParser.RawConfigParser()   
@@ -56,6 +56,7 @@ class Controller(object):
 		pass
 
 
+
 class IoTLAB(Controller):
 
 	def __init__(self, user_id, scenario, action):
@@ -77,7 +78,7 @@ class IoTLAB(Controller):
 		self.reservation = IoTLABReservation(user_id, self.USERNAME, self.HOSTNAME, self.BROKER, self.OTB_REPO, self.OTB_TAG, self.EXP_DURATION, self.NODES)
 
 		self.mqtt_client = MQTTClient.create('iotlab', user_id)
-
+		atexit.register(self._stop_mqtt)
 
 	def add_files_from_env(self):
 		if self.PRIVATE_SSH != "":
@@ -99,6 +100,9 @@ class IoTLAB(Controller):
 				nodes_str += config_obj[generic_id]["node_id"].split("-")[2] + "+"
 
 			return nodes_str.rstrip("+")
+
+	def _stop_mqtt(self):
+		self.mqtt_client.clear_state()
 
 
 
@@ -137,7 +141,7 @@ class Wilab(Controller):
 
 		self.reservation = WilabReservation(user_id, self.JFED_DIR, self.RUN, self.DELETE, self.DISPLAY)
 		self.mqtt_client = MQTTClient.create('iotlab', user_id)
-
+		atexit.register(self._stop_mqtt)
 
 	def add_files_from_env(self):
 		if self.CERTIFICATE_B64 != "":
@@ -261,6 +265,9 @@ class Wilab(Controller):
 	def _get_random_string(self, string_length = 5):
 		letters = string.ascii_uppercase
 		return ''.join(random.choice(letters) for i in range(string_length))
+
+	def _stop_mqtt(self):
+		self.mqtt_client.clear_state()
 
 
 

--- a/experiment_provisioner/mqtt_client.py
+++ b/experiment_provisioner/mqtt_client.py
@@ -50,7 +50,6 @@ class MQTTClient:
 		self.client.on_subscribe  = self._on_subscribe
 		self.client.on_message    = self._on_message
 		self.successful_subs      = 0
-		
 
 	def _subscribe(self):
 		for key in self.sub_topics:
@@ -89,7 +88,7 @@ class MQTTClient:
 		self.data_stream_started = True
 
 
-	##### Public methodss #####
+	##### Public methods #####
 	def push_notification(self, step_identifier, success):
 		try:
 			if step_identifier not in ['provisioned', 'flashed', 'data-stream-started', 'terminated']:
@@ -130,3 +129,7 @@ class MQTTClient:
 				"action": action,
 				"log_entry": log_entry
 			})
+
+	def clear_state(self):
+		self.client.loop_stop()
+		self.client.disconnect()

--- a/experiment_provisioner/reservation.py
+++ b/experiment_provisioner/reservation.py
@@ -100,7 +100,8 @@ class IoTLABReservation(Reservation):
 
     def reserve_experiment(self):
         if self.check_experiment():
-            print('Experiment already exists')
+            print('Resources already reserved. Moving on...')
+            self.mqtt_client.push_debug_log('NODE_RESERVATION', 'Resources already reserved. Moving on...')
         else:
             output = self.ssh_command_exec(
                 'iotlab-experiment submit -n a8_exp -d ' + str(self.duration) + ' -l ' + self.nodes)

--- a/experiment_provisioner/reservation.py
+++ b/experiment_provisioner/reservation.py
@@ -29,7 +29,7 @@ class Reservation:
 
 class IoTLABReservation(Reservation):
     CMD_ERROR = "cmd_error"
-    SSH_RETRY_TIME = 120
+    SSH_RETRY_TIME = 240
     RETRY_PAUSE = 10
 
     def __init__(self, user_id, user, domain, broker, otb_repo, otb_tag, duration=None, nodes=None):

--- a/web/resources/assets/js/components/charts/LineChart.vue
+++ b/web/resources/assets/js/components/charts/LineChart.vue
@@ -16,7 +16,10 @@
                 titles: {
                     "latency": "Latency",
                     "reliability": "Reliability",
-                    "radioDutyCycle": "Duty Cycle"
+                    "radioDutyCycle": "Duty Cycle",
+                    "syncronizationPhase": "Synchronization",
+                    "secureJoinPhase": "Secure join phase",
+                    "networkFormationTime": "Network formation time"
                 }
             }
         },

--- a/web/resources/assets/js/components/landing/Graphs.vue
+++ b/web/resources/assets/js/components/landing/Graphs.vue
@@ -115,9 +115,7 @@
                     */
                 },
                 generalDataTitles: {
-                    "networkFormationTime": "Network formation",
-                    "syncronizationPhase" : "Synchronization",
-                    "secureJoinPhase"     : "Secure join phase"
+                    
                 },
 
                 dataset: {

--- a/web/resources/assets/js/components/landing/Graphs.vue
+++ b/web/resources/assets/js/components/landing/Graphs.vue
@@ -38,9 +38,9 @@
                     </div>
                 </div>
 
-                <div class="card col-direction bordered relative" style="width: 100%; height: 50%;">
-                    <span class="mt-1" v-for="key in Object.keys(lastData)">
-                        <span class="ml-1 mr-1">{{lastDataTitles[key]}}: <span class="bold">{{lastData[key]}}</span></span>
+                <div class="card col-direction bordered relative pt-1" style="width: 100%; height: 50%;">
+                    <span class="col-direction" v-for="nodeId in Object.keys(lastData)" v-if="nodeId === selectedNodeKey">
+                        <span class="ml-1 mr-1 mb-1" v-for="key in Object.keys(lastData[nodeId])">{{lastDataTitles[key]}}: <span class="bold">{{lastData[nodeId][key]}}</span></span>
                     </span>
 
                     <i id="file-download" class="fas fa-file-download fa-2x clickable" @click="showModal('file-download')" v-if="experimentId !== undefined"></i>

--- a/web/resources/assets/js/components/landing/Graphs.vue
+++ b/web/resources/assets/js/components/landing/Graphs.vue
@@ -39,8 +39,8 @@
                 </div>
 
                 <div class="card col-direction bordered relative" style="width: 100%; height: 50%;">
-                    <span class="mt-1" v-for="key in Object.keys(generalData)">
-                        <span class="ml-1 mr-1">{{generalDataTitles[key]}}: <span class="bold">{{generalData[key]}}</span></span>
+                    <span class="mt-1" v-for="key in Object.keys(lastData)">
+                        <span class="ml-1 mr-1">{{lastDataTitles[key]}}: <span class="bold">{{lastData[key]}}</span></span>
                     </span>
 
                     <i id="file-download" class="fas fa-file-download fa-2x clickable" @click="showModal('file-download')" v-if="experimentId !== undefined"></i>
@@ -108,14 +108,19 @@
 
                 headerData: {},
 
-                generalData: {
+                lastData: {
                     /* EXAMPLE ITEM: 
-                    "networkFormationTime": 1560761378.408148, 
+                    "node-a8-106": {
+                        "syncronizationPhase": 1560761378.408148, 
+                        ...
+                    }
                     ... 
                     */
                 },
-                generalDataTitles: {
-                    
+                lastDataTitles: {
+                    "syncronizationPhase": "Last synchronization",
+                    "secureJoinPhase": "Last secure join",
+                    "networkFormationTime": "Network formation time"
                 },
 
                 dataset: {
@@ -133,6 +138,25 @@
                     ...
                     */
                 }
+            }
+        },
+
+        watch: {
+            dataset: function(val) {
+                let newLastData = {}
+
+                Object.keys(this.dataset).forEach(nodeId => {
+                    newLastData[nodeId] = {}
+                    Object.keys(this.lastDataTitles).forEach(key => {
+                        if (this.dataset[nodeId] !== undefined && this.dataset[nodeId][key] !== undefined) {
+                            let timestampVals = this.dataset[nodeId][key]["timestamp"]
+                            newLastData[nodeId][key] = timestampVals[timestampVals.length - 1]
+                        }
+                    })
+                })
+
+                console.log(JSON.stringify(newLastData))
+                this.lastData = newLastData
             }
         },
 
@@ -169,7 +193,6 @@
                 axios.get('/api/logs/data-fetch/' + this.experimentId)
                     .then(function (response) {
                         thisComponent.headerData = response.data.message.header
-                        thisComponent.generalData = response.data.message.general_data
                         thisComponent.dataset = response.data.message.data
                         thisComponent.$eventHub.$emit('LOG_DATA_FETCHED', thisComponent.headerData);
                     })
@@ -204,16 +227,7 @@
 
                     this.dataset = newObj
 
-                } else   // General data not related to a single node
-                    this.updateGeneralData(label, timestamp);
-            },
-
-            updateGeneralData(label, timestamp) {
-                let newObj = this.clone(this.generalData)
-                newObj[label] = timestamp
-                this.generalData = newObj
-                console.log("General data updated:")
-                console.log(JSON.stringify(this.generalData))
+                }
             },
 
             parseLogData(obj) {


### PR DESCRIPTION
This PR calculates all the current KPIs per node, instead of treating several specific KPIs as global network parameters. Additionally, for these specific KPIs (`synchronizationPhase`, `secureJoinPhase` and `networkFormationTime`) the last timestamp value is always shown on the graphs panel, as an additional information. Moreover, this PR fixes two bugs:

- Increases experiment check retry time to avoid provisioning failure due to the nodes not being properly started on IoT-LAB
- Stops loop and disconnects the client within Paho MQTT module, at exit, to prevent exceptions raised during the interpreter shutdown